### PR TITLE
Free libusb device list in list_connected

### DIFF
--- a/src/freesrp_impl.cpp
+++ b/src/freesrp_impl.cpp
@@ -246,6 +246,7 @@ std::vector<std::string> FreeSRP::FreeSRP::impl::list_connected()
         }
     }
 
+    libusb_free_device_list(devs, 1);
     libusb_exit(list_ctx);
 
     return list;


### PR DESCRIPTION
Valgrind shows that `list_connected` leaks about 26 kB of memory on each execution. This happens because the libusb device list allocated on line 209 is not freed.